### PR TITLE
Support 0-conditioned control qubits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ qiskit's QuantumCircuit
 
 ```python
 import qiskit
-from qiskit.circuit.library import HGate
+from qiskit.circuit.library import HGate, XGate
 
 q = qiskit.QuantumRegister(14)
 c = qiskit.ClassicalRegister(14)
@@ -14,6 +14,8 @@ qc.x(q[0])
 qc.cx(q[0], q[3])
 qc.ccx(q[0], q[1], q[2])
 qc.mcx(q[1:6], q[0])
+
+qc.append(XGate().control(2, ctrl_state=0b10), [q[0], q[1], q[4]])
 
 qc.h(q[0])
 qc.ch(q[0],q[1])
@@ -27,6 +29,8 @@ qc.measure(q[3], c[0])
 
 C++ code
 
+The third argument of each gate lists the control qubit indices that must be 0.
+
 ```c++
 set_num_qubits(14);
 set_num_clbits(14);
@@ -34,6 +38,7 @@ sim.gate_x({0}, {}, {});
 sim.gate_x({3}, {0}, {});
 sim.gate_x({2}, {0,1}, {});
 sim.gate_x({0}, {1,2,3,4,5}, {});
+sim.gate_x({4}, {0,1}, {0});
 sim.gate_h({0}, {}, {});
 sim.gate_h({1}, {0}, {});
 sim.gate_h({13}, {0,1,2,3,4,5,6,7,8,9,10,11,12}, {});


### PR DESCRIPTION
## Summary
- handle control qubits conditioned on 0 when converting Qiskit circuits to C++
- document usage and example of zero-conditioned controls

## Testing
- `python qc2cpp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3fb9d4af4832bb29659323006ba8f